### PR TITLE
Ubuntu 14.04 build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Drift       | Comma    | C        | 4
 Use powerup | Period   | V        | 5
 
 Some pseudo C code to use it:
+
 ```C
     #define NET_INPUT_UP 1<<0
     #define NET_INPUT_DOWN 1<<1
@@ -34,6 +35,7 @@ Some pseudo C code to use it:
 
 On connect you will receive a JSON object giving you your ID and describing the
 map:
+
 ```JSON
 {
     "id": 0,
@@ -94,6 +96,7 @@ github or contact us otherwise so we can explain better here).
 
 Then, each time you send a command (invalid or valid), you will get back a
 status update JSON object like this:
+
 ```JSON
 {
     "cars": [
@@ -137,7 +140,6 @@ status update JSON object like this:
     ]
 }
 ```
-
 
 **NOTE: the actual JSON you receive is minified, and each initial or status update is a single
 object on a single line, terminated by a newline:**

--- a/README.md
+++ b/README.md
@@ -150,7 +150,22 @@ object on a single line, terminated by a newline:**
 
 
 ### Build instructions
-Install the SDL2 development headers, and run "make".
+TL;DR: Install the SDL2 development headers, and run "make".
+
+#### Building on Ubuntu
+On Ubuntu (14.04), which packages you need to install might not be obvious, so try this:
+
+```bash
+sudo apt-get install build-essential libsdl2-dev libsdl2-gfx-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-net-dev libsdl2-ttf-dev
+```
+
+From there, it's just to run `make`, make `kart` executable, and execute!
+
+```bash
+make
+chmod +x kart
+./kart
+```
 
 ### CREDITS:
 Graphics by 'Kari Nordmann' (alias).

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ On Ubuntu (14.04), which packages you need to install might not be obvious, so t
 sudo apt-get install build-essential libsdl2-dev libsdl2-gfx-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-net-dev libsdl2-ttf-dev
 ```
 
-From there, it's just to run `make`, make `kart` executable, and execute!
+From there, it's just to run `make`, turn `kart` into an executable, and execute it!
 
 ```bash
 make


### PR DESCRIPTION
Adds build instructions for Ubuntu 14.04. Build instructions for other Linux distributions as well as other *nix-es would be nice to have, but I don't have any other than OS X at hand and couldn't figure out how to build it there.
